### PR TITLE
Adding Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/client/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Adding dependabot to auto-upgrade dependencies, read more at https://docs.github.com/en/code-security/dependabot.